### PR TITLE
Avoid yearly updates to this file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2018 Eric Barnes
+Copyright (c) Eric Barnes
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
This PR addresses the removal of the year on the license file just to avoid yearly updates on it.